### PR TITLE
Enable SSM commands from the local machine

### DIFF
--- a/CDK/lib/CCLStack.js
+++ b/CDK/lib/CCLStack.js
@@ -103,7 +103,11 @@ export default class CCLStack extends Stack {
                 "logs:CreateLogStream",
                 "logs:DescribeLogStreams",
                 "logs:PutLogEvents",
-                "ec2:DescribeInstances"
+                "ec2:DescribeInstanceStatus",
+                "ec2:DescribeInstances",
+                "ssm:SendCommand",
+                "ssm:ListInstanceAssociations",
+                "ssm:UpdateInstanceInformation",
               ],
               resources: [
                 "*"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ Optional parameters:
   - name of the namespace to view the metrics
 - loadTestSessionName
   - session name assigned to the load test
-
+- isLocalMachine
+  - to run the test on your local machine
+  
 Usage:
 
 ```

--- a/src/ClientLauncher.js
+++ b/src/ClientLauncher.js
@@ -48,7 +48,7 @@ export default class ClientLauncher {
 
   async run() {
     if (isMainThread) {
-      this.support.putMetricData('LauncherRunning', 500);
+      this.support.putMetricData('LauncherRunning', 1);
       const threads = new Set();
       const sharedConfigParameters = this.getSharedConfigParameters();
       const threadActivity = new ThreadActivity(sharedConfigParameters, this.support);
@@ -56,7 +56,7 @@ export default class ClientLauncher {
       this.support.log('ThreadCount: ' + this.threadsCount);
       this.support.log('No Of Meetings: ' + this.noOfMeetings);
       this.support.log('No Of Attendees: ' + this.attendeesPerMeetingCount);
-      this.support.putMetricData('meetingAttendeeObjectsLength', this.attendeesPerMeetingCount);
+      this.support.putMetricData('MeetingAttendeeObjectsLength', this.noOfMeetings * this.attendeesPerMeetingCount);
 
       const loadTestStartTimeStampEpoch = Date.now();
       await threadActivity.spawnThreads(


### PR DESCRIPTION
*Issue #, if available:*
With the new permission set, we will be able to send SSM commands from the local machine to all the EC2 instances associated to the AWS Cloud Formation stack.

*Description of changes:*
Enable SSM commands from the local machine.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
